### PR TITLE
Questions refactor

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -31,6 +31,13 @@ export const FIELD_TYPES_EXCLUDE_MIN_MAX = [
   'DynamicRadioList'
 ]
 
+/**
+ * Checks if a given field type is in the exclusion list provided
+ */
+export function isFieldTypeInExclusionList(fieldType: string, exclusionList: string[]) {
+  return exclusionList.includes(fieldType)
+}
+
 export const NONE = '<none>'
 export const CUSTOM = '<custom>'
 export const CANCEL = '<cancel>'

--- a/et/configs.ts
+++ b/et/configs.ts
@@ -48,7 +48,11 @@ const roleMappings: RoleMappings = {
  * @returns parsed JSON file
  */
 function getJson(regionDir: string, name: string) {
-  return JSON.parse(readFileSync(`${regionDir}${sep}definitions${sep}json${sep}${name}.json`).toString())
+  try {
+    return JSON.parse(readFileSync(`${regionDir}${sep}definitions${sep}json${sep}${name}.json`).toString())
+  } catch (e) {
+    throw new Error(`Failed to read ${name}.json in ${regionDir}`)
+  }
 }
 
 /** Getter for readTime */

--- a/et/questions.ts
+++ b/et/questions.ts
@@ -1,0 +1,180 @@
+import { CUSTOM, NONE } from 'app/constants'
+import { format, getIdealSizeForInquirer } from 'app/helpers'
+import { createEvent } from 'app/journeys/et/createEvent'
+import { Answers, askBasicFreeEntry, fuzzySearch } from 'app/questions'
+import { session } from 'app/session'
+import { CaseEventKeys, CaseEventToFieldKeys, CaseFieldKeys, EventToComplexTypeKeys } from 'app/types/ccd'
+import { prompt } from 'inquirer'
+import { getCaseEventIDOpts, getKnownCaseFieldIDs, getKnownCaseFieldTypeParameters, getKnownCaseFieldTypes, getKnownCaseTypeIDs } from 'app/et/configs'
+import { createSingleField } from 'app/journeys/et/createSingleField'
+import { createScrubbed } from 'app/journeys/et/createScrubbed'
+
+const QUESTION_CASE_EVENT_ID = 'What event does this belong to?'
+const QUESTION_CASE_FIELD_ID = 'What field does this reference?'
+const QUESTION_FIELD_TYPE_PARAMETER = 'What\'s the parameter for this {0} field?'
+const QUESTION_FIELD_TYPE = 'What\'s the type of this field?'
+const QUESTION_FIELD_TYPE_CUSTOM = 'What\'s the name of the FieldType?'
+const QUESTION_CASE_TYPE_ID = 'What\'s the CaseTypeID?'
+const QUESTION_CASE_TYPE_ID_CUSTOM = 'Enter a custom value for CaseTypeID'
+
+/**
+ * Asks questions based on the keys contained in the target object type
+ * (convenience method for not creating a custom method for asking questions)
+ * @param answers An existing answers object that may have answers already filled
+ * @param keys An enum representing the keys on the target object (ie, CaseFieldKeys)
+ * @param obj A blank/default object of the target type (ie, createNewCaseField)
+ * @returns An answers object with answers to questions automatically asked based on the passed in object
+ */
+export async function createTemplate<T, P>(answers: Answers = {}, keys: T, obj: P) {
+  const fields = Object.keys(keys)
+
+  const tasks: Array<() => Promise<void>> = []
+
+  for (const field of fields) {
+    const question = { name: field, message: `Give a value for ${field}`, type: 'input', default: session.lastAnswers[field] }
+
+    if (typeof (obj[field]) === 'number') {
+      question.type = 'number'
+    }
+
+    if (field === 'CaseEventID') {
+      tasks.push(async () => { answers = await askCaseEvent(answers, undefined, undefined, true) })
+    } else if (field === 'CaseTypeID') {
+      tasks.push(async () => { answers = await askCaseTypeID(answers) })
+    } else if (field === 'CaseFieldID') {
+      tasks.push(async () => { answers = await askCaseFieldID(answers) })
+    } else {
+      tasks.push(async () => { answers = await prompt([question], answers) })
+    }
+  }
+
+  for (const task of tasks) {
+    await task()
+  }
+
+  return answers
+}
+
+export async function askCaseEvent(answers: Answers = {}, key?: string, message?: string, allowNone = false) {
+  const opts = getCaseEventIDOpts()
+  key = key || CaseEventToFieldKeys.CaseEventID
+  const choices = [CUSTOM, ...opts]
+  if (allowNone) {
+    choices.splice(0, 0, NONE)
+  }
+  answers = await prompt([
+    {
+      name: key,
+      message: message || QUESTION_CASE_EVENT_ID,
+      type: 'autocomplete',
+      source: (_answers: unknown, input: string) => fuzzySearch(choices, input),
+      default: session.lastAnswers[key],
+      pageSize: getIdealSizeForInquirer()
+    }
+  ], answers)
+
+  if (answers[key] === CUSTOM) {
+    answers[key] = await createEvent({ CaseTypeID: answers[CaseEventKeys.CaseTypeID] })
+  }
+
+  return answers
+}
+
+/**
+ * Asks the user for a CaseTypeID. Allows for creation if <custom> is selected.
+ * @returns extended answers object as passed in
+ */
+export async function askCaseTypeID(answers: Answers = {}, key?: string, message?: string) {
+  const opts = getKnownCaseTypeIDs()
+  key = key || CaseFieldKeys.CaseTypeID
+
+  answers = await prompt([
+    {
+      name: key,
+      message: message || QUESTION_CASE_TYPE_ID,
+      type: 'autocomplete',
+      source: (_answers: unknown, input: string) => fuzzySearch([CUSTOM, ...opts], input),
+      default: session.lastAnswers[key],
+      pageSize: getIdealSizeForInquirer()
+    }
+  ], answers)
+
+  if (answers[key] === CUSTOM) {
+    const newEventTypeAnswers = await askBasicFreeEntry({}, key, QUESTION_CASE_TYPE_ID_CUSTOM)
+    answers[key] = newEventTypeAnswers[key]
+    // TODO: There's no support for CaseType.json yet so theres no flow to create one. But we could...
+  }
+
+  return answers
+}
+
+export async function askCaseFieldID(answers: Answers = {}, key?: string, message?: string) {
+  const opts = getKnownCaseFieldIDs()
+  key = key || EventToComplexTypeKeys.CaseFieldID
+
+  answers = await prompt([
+    {
+      name: key,
+      message: message || QUESTION_CASE_FIELD_ID,
+      type: 'autocomplete',
+      source: (_answers: unknown, input: string) => fuzzySearch([CUSTOM, ...opts], input),
+      pageSize: getIdealSizeForInquirer()
+    }
+  ], answers)
+
+  if (answers[key] === CUSTOM) {
+    answers[key] = await createSingleField({
+      [CaseFieldKeys.CaseTypeID]: answers[CaseFieldKeys.CaseTypeID],
+      [CaseEventToFieldKeys.CaseEventID]: answers[CaseEventToFieldKeys.CaseEventID]
+    })
+  }
+
+  return answers
+}
+
+export async function askFieldTypeParameter(answers: Answers = {}, key?: string, message?: string) {
+  const opts = getKnownCaseFieldTypeParameters()
+  key = key || CaseFieldKeys.FieldTypeParameter
+
+  answers = await prompt([
+    {
+      name: key,
+      message: message || format(QUESTION_FIELD_TYPE_PARAMETER, answers[CaseFieldKeys.FieldType]),
+      type: 'autocomplete',
+      source: (_answers: unknown, input: string) => fuzzySearch([NONE, CUSTOM, ...opts], input),
+      pageSize: getIdealSizeForInquirer()
+    }
+  ], answers)
+
+  if (answers[key] === NONE) {
+    answers[key] = ''
+  } else if (answers[key] === CUSTOM) {
+    answers[key] = await createScrubbed({})
+  }
+
+  return answers
+}
+
+export async function askFieldType(answers: Answers = {}, key?: string, message?: string) {
+  const opts = getKnownCaseFieldTypes()
+  key = key || CaseFieldKeys.FieldType
+
+  answers = await prompt([
+    {
+      name: key,
+      message: message || QUESTION_FIELD_TYPE,
+      type: 'autocomplete',
+      source: (_answers: unknown, input: string) => fuzzySearch([CUSTOM, ...opts], input),
+      default: 'Label',
+      pageSize: getIdealSizeForInquirer()
+    }
+  ], answers)
+
+  if (answers[key] === CUSTOM) {
+    const customFieldType = await askBasicFreeEntry({}, key, QUESTION_FIELD_TYPE_CUSTOM)
+    answers[key] = customFieldType[key]
+    // TODO: Add ComplexType creation route here when ComplexType support is added
+  }
+
+  return answers
+}

--- a/journeys/et/createCallbackPopulatedLabel.ts
+++ b/journeys/et/createCallbackPopulatedLabel.ts
@@ -1,12 +1,13 @@
 import { prompt } from 'inquirer'
 import { CaseEventToFieldKeys, CaseFieldKeys } from 'types/ccd'
 import { Journey } from 'types/journey'
-import { Answers, askCaseTypeID } from 'app/questions'
+import { Answers, askForPageFieldDisplayOrder, askForPageID } from 'app/questions'
 import { createNewCaseEventToField, createNewCaseField, trimCaseEventToField, trimCaseField } from 'app/ccd'
 import { addToInMemoryConfig, createCaseFieldAuthorisations } from 'app/et/configs'
-import { askCaseEvent, askFirstOnPageQuestions, askForPageIDAndDisplayOrder, QUESTION_FIELD_SHOW_CONDITION, QUESTION_ID } from './createSingleField'
+import { askFirstOnPageQuestions, QUESTION_FIELD_SHOW_CONDITION, QUESTION_ID } from './createSingleField'
 import { addOnDuplicateQuestion } from './manageDuplicateField'
 import { addToLastAnswers } from 'app/session'
+import { askCaseEvent, askCaseTypeID } from 'app/et/questions'
 
 export async function createCallbackPopulatedLabel(answers: Answers = {}) {
   answers = await askCaseTypeID(answers)
@@ -19,7 +20,8 @@ export async function createCallbackPopulatedLabel(answers: Answers = {}) {
     ], answers
   )
 
-  answers = await askForPageIDAndDisplayOrder(answers)
+  answers = await askForPageID(answers)
+  answers = await askForPageFieldDisplayOrder(answers)
 
   if (answers[CaseEventToFieldKeys.PageFieldDisplayOrder] === 1) {
     answers = await askFirstOnPageQuestions(answers)

--- a/journeys/et/createEvent.ts
+++ b/journeys/et/createEvent.ts
@@ -1,9 +1,10 @@
 import { prompt } from 'inquirer'
 import { Journey } from 'types/journey'
-import { Answers, askCaseTypeID } from 'app/questions'
+import { Answers } from 'app/questions'
 import { createNewCaseEvent } from 'app/ccd'
 import { addToInMemoryConfig, createCaseEventAuthorisations, upsertNewCaseEvent } from 'app/et/configs'
 import { Y_OR_N } from 'app/constants'
+import { askCaseTypeID } from 'app/et/questions'
 
 const QUESTION_NAME = 'Give the new event a name (shows in the event dropdown)'
 const QUESTION_DESCRIPTION = 'Give the new event a description'

--- a/journeys/et/createSingleField.ts
+++ b/journeys/et/createSingleField.ts
@@ -1,41 +1,41 @@
 import { prompt } from 'inquirer'
 import { addToLastAnswers, session } from 'app/session'
-import { CaseEventKeys, CaseEventToFieldKeys, CaseFieldKeys } from 'types/ccd'
-import { Answers, askBasicFreeEntry, askCaseTypeID, fuzzySearch } from 'app/questions'
-import { CUSTOM, DISPLAY_CONTEXT_OPTIONS, FIELD_TYPES_EXCLUDE_MIN_MAX, FIELD_TYPES_EXCLUDE_PARAMETER, NONE, YES_OR_NO, Y_OR_N } from 'app/constants'
-import { addToInMemoryConfig, createCaseFieldAuthorisations, getCaseEventIDOpts, getKnownCaseFieldTypeParameters, getKnownCaseFieldTypes, getNextPageFieldIDForPage } from 'app/et/configs'
+import { CaseEventToFieldKeys, CaseFieldKeys } from 'types/ccd'
+import { Answers, askForPageFieldDisplayOrder, askForPageID, askForRegularExpression, askMinAndMax, askRetainHiddenValue } from 'app/questions'
+import { DISPLAY_CONTEXT_OPTIONS, FIELD_TYPES_EXCLUDE_MIN_MAX, FIELD_TYPES_EXCLUDE_PARAMETER, isFieldTypeInExclusionList, NONE, Y_OR_N } from 'app/constants'
+import { addToInMemoryConfig, createCaseFieldAuthorisations, getNextPageFieldIDForPage } from 'app/et/configs'
 import { addOnDuplicateQuestion } from './manageDuplicateField'
 import { createNewCaseEventToField, createNewCaseField, trimCaseEventToField, trimCaseField } from 'app/ccd'
-import { createScrubbed } from './createScrubbed'
-import { createEvent } from './createEvent'
-import { format, getIdealSizeForInquirer } from 'app/helpers'
 import { Journey } from 'types/journey'
 import { doDuplicateCaseField } from 'app/et/duplicateCaseField'
+import { askCaseEvent, askCaseTypeID, askFieldType, askFieldTypeParameter } from 'app/et/questions'
 
 export const QUESTION_ID = 'What\'s the ID for this field?'
 const QUESTION_LABEL = 'What text (Label) should this field have?'
-const QUESTION_PAGE_ID = 'What page will this field appear on?'
-const QUESTION_PAGE_FIELD_DISPLAY_ORDER = 'Whats the PageFieldDisplayOrder for this field?'
+
 export const QUESTION_FIELD_SHOW_CONDITION = 'Enter a field show condition string (optional)'
 const QUESTION_CASE_EVENT_ID = 'What event does this new field belong to?'
-const QUESTION_FIELD_TYPE_PARAMETER = 'What\'s the parameter for this {0} field?'
-const QUESTION_FIELD_TYPE = 'What\'s the type of this field?'
-const QUESTION_FIELD_TYPE_CUSTOM = 'What\'s the name of the FieldType?'
 export const QUESTION_HINT_TEXT = 'What HintText should this field have? (optional)'
 const QUESTION_DISPLAY_CONTEXT = 'Is this field READONLY, OPTIONAL, MANDATORY or COMPLEX?'
 const QUESTION_SHOW_SUMMARY_CHANGE_OPTION = 'Should this field appear on the CYA page?'
-const QUESTION_MIN = 'Enter a min for this field (optional)'
-const QUESTION_MAX = 'Enter a max for this field (optional)'
+
 const QUESTION_PAGE_LABEL = 'Does this page have a custom title? (optional)'
 const QUESTION_PAGE_SHOW_CONDITION = 'Enter a page show condition string (optional)'
 const QUESTION_CALLBACK_URL_MID_EVENT = 'Enter the callback url to hit before loading the next page (optional)'
-const QUESTION_REGULAR_EXPRESSION = 'Do we need a RegularExpression for the field?'
-export const QUESTION_RETAIN_HIDDEN_VALUE = 'Should the field retain its value when hidden?'
+
+function shouldAskEventQuestions(answers: Answers) {
+  return answers[CaseEventToFieldKeys.CaseEventID] !== NONE
+}
 
 export async function createSingleField(answers: Answers = {}) {
   answers = await askBasic(answers)
 
-  answers = await askForPageIDAndDisplayOrder(answers)
+  const askEvent = answers[CaseEventToFieldKeys.CaseEventID] !== NONE
+
+  if (askEvent) {
+    answers = await askForPageID(answers)
+    answers = await askForPageFieldDisplayOrder(answers, undefined, undefined, getDefaultForPageFieldDisplayOrder(answers))
+  }
 
   answers = await askFieldType(answers)
 
@@ -47,7 +47,7 @@ export async function createSingleField(answers: Answers = {}) {
     answers = await askNonLabelQuestions(answers)
   }
 
-  if (answers[CaseEventToFieldKeys.PageFieldDisplayOrder] === 1) {
+  if (askEvent && answers[CaseEventToFieldKeys.PageFieldDisplayOrder] === 1) {
     answers = await askFirstOnPageQuestions(answers)
   }
 
@@ -59,16 +59,20 @@ export async function createSingleField(answers: Answers = {}) {
     answers = await askMinAndMax(answers)
   }
 
+  if (askEvent && answers[CaseEventToFieldKeys.FieldShowCondition]) {
+    answers = await askRetainHiddenValue(answers)
+  }
+
   addToLastAnswers(answers)
 
   const caseField = createNewCaseField(answers)
-  const caseEventToField = createNewCaseEventToField(answers)
+  const caseEventToField = askEvent ? createNewCaseEventToField(answers) : undefined
   const authorisations = createCaseFieldAuthorisations(answers.CaseTypeID, answers.ID)
 
   addToInMemoryConfig({
     AuthorisationCaseField: authorisations,
     CaseField: [trimCaseField(caseField)],
-    CaseEventToFields: [trimCaseEventToField(caseEventToField)]
+    CaseEventToFields: askEvent ? [trimCaseEventToField(caseEventToField)] : []
   })
 
   doDuplicateCaseField(answers.CaseTypeID, answers.ID, answers.CaseTypeID)
@@ -77,14 +81,7 @@ export async function createSingleField(answers: Answers = {}) {
   return answers.ID
 }
 
-/**
- * Checks if a given field type is in the exclusion list provided
- */
-function isFieldTypeInExclusionList(fieldType: string, exclusionList: string[]) {
-  return exclusionList.includes(fieldType)
-}
-
-export function getDefaultForPageFieldDisplayOrder(answers: Answers = {}) {
+function getDefaultForPageFieldDisplayOrder(answers: Answers = {}) {
   const pageID = CaseEventToFieldKeys.PageID
   const pageFieldDisplayOrder = CaseEventToFieldKeys.PageFieldDisplayOrder
   if (answers[pageID] && answers[CaseEventToFieldKeys.CaseEventID] && answers[CaseEventToFieldKeys.CaseTypeID]) {
@@ -102,111 +99,22 @@ export function getDefaultForPageFieldDisplayOrder(answers: Answers = {}) {
 
 async function askBasic(answers: Answers = {}) {
   answers = await askCaseTypeID(answers)
-  answers = await askCaseEvent(answers)
+  answers = await askCaseEvent(answers, undefined, QUESTION_CASE_EVENT_ID, true)
 
   return await prompt(
     [
       { name: CaseFieldKeys.ID, message: QUESTION_ID, type: 'input', default: 'id' },
       { name: CaseFieldKeys.Label, message: QUESTION_LABEL, type: 'input', default: 'text' },
-      { name: CaseEventToFieldKeys.FieldShowCondition, message: QUESTION_FIELD_SHOW_CONDITION, type: 'input' }
+      { name: CaseEventToFieldKeys.FieldShowCondition, message: QUESTION_FIELD_SHOW_CONDITION, type: 'input', when: shouldAskEventQuestions }
     ], answers
   )
-}
-
-export async function askForPageIDAndDisplayOrder(answers: Answers = {}) {
-  answers = await prompt([{
-    name: CaseEventToFieldKeys.PageID,
-    message: QUESTION_PAGE_ID,
-    type: 'number',
-    default: session.lastAnswers.PageID || 1
-  }], answers)
-
-  return await prompt([{
-    name: CaseEventToFieldKeys.PageFieldDisplayOrder,
-    message: QUESTION_PAGE_FIELD_DISPLAY_ORDER,
-    type: 'number',
-    default: getDefaultForPageFieldDisplayOrder(answers)
-  }], answers)
-}
-
-export async function askCaseEvent(answers: Answers = {}, message?: string) {
-  const opts = getCaseEventIDOpts()
-  const key = CaseEventToFieldKeys.CaseEventID
-  answers = await prompt([
-    {
-      name: key,
-      message: message || QUESTION_CASE_EVENT_ID,
-      type: 'autocomplete',
-      source: (_answers: unknown, input: string) => fuzzySearch([CUSTOM, ...opts], input),
-      default: session.lastAnswers[key],
-      pageSize: getIdealSizeForInquirer()
-    }
-  ], answers)
-
-  if (answers[key] === CUSTOM) {
-    answers[key] = await createEvent({ CaseTypeID: answers[CaseEventKeys.CaseTypeID] })
-  }
-
-  return answers
-}
-
-async function askFieldTypeParameter(answers: Answers = {}) {
-  const opts = getKnownCaseFieldTypeParameters()
-  const key = CaseFieldKeys.FieldTypeParameter
-  answers = await prompt([
-    {
-      name: key,
-      message: format(QUESTION_FIELD_TYPE_PARAMETER, answers[CaseFieldKeys.FieldType]),
-      type: 'autocomplete',
-      source: (_answers: unknown, input: string) => fuzzySearch([NONE, CUSTOM, ...opts], input),
-      pageSize: getIdealSizeForInquirer()
-    }
-  ], answers)
-
-  if (answers[key] === NONE) {
-    answers[key] = ''
-  } else if (answers[key] === CUSTOM) {
-    answers[key] = await createScrubbed({})
-  }
-
-  return answers
-}
-
-async function askFieldType(answers: Answers = {}) {
-  const opts = getKnownCaseFieldTypes()
-  const key = CaseFieldKeys.FieldType
-  answers = await prompt([
-    {
-      name: key,
-      message: QUESTION_FIELD_TYPE,
-      type: 'autocomplete',
-      source: (_answers: unknown, input: string) => fuzzySearch([CUSTOM, ...opts], input),
-      default: 'Label',
-      pageSize: getIdealSizeForInquirer()
-    }
-  ], answers)
-
-  if (answers[key] === CUSTOM) {
-    const customFieldType = await askBasicFreeEntry({}, key, QUESTION_FIELD_TYPE_CUSTOM)
-    answers[key] = customFieldType[key]
-    // TODO: Add ComplexType creation route here when ComplexType support is added
-  }
-
-  return answers
 }
 
 async function askNonLabelQuestions(answers: Answers = {}) {
   return await prompt([
     { name: CaseFieldKeys.HintText, message: QUESTION_HINT_TEXT, type: 'input' },
     { name: CaseEventToFieldKeys.DisplayContext, message: QUESTION_DISPLAY_CONTEXT, type: 'list', choices: DISPLAY_CONTEXT_OPTIONS, default: DISPLAY_CONTEXT_OPTIONS[1] },
-    { name: CaseEventToFieldKeys.ShowSummaryChangeOption, message: QUESTION_SHOW_SUMMARY_CHANGE_OPTION, type: 'list', choices: Y_OR_N, default: 'Y' }
-  ], answers)
-}
-
-export async function askMinAndMax(answers: Answers = {}) {
-  return await prompt([
-    { name: CaseFieldKeys.Min, message: QUESTION_MIN },
-    { name: CaseFieldKeys.Max, message: QUESTION_MAX }
+    { name: CaseEventToFieldKeys.ShowSummaryChangeOption, message: QUESTION_SHOW_SUMMARY_CHANGE_OPTION, type: 'list', choices: Y_OR_N, default: 'Y', when: shouldAskEventQuestions }
   ], answers)
 }
 
@@ -214,14 +122,7 @@ export async function askFirstOnPageQuestions(answers: Answers = {}) {
   return await prompt([
     { name: CaseEventToFieldKeys.PageLabel, message: QUESTION_PAGE_LABEL, type: 'input' },
     { name: CaseEventToFieldKeys.PageShowCondition, message: QUESTION_PAGE_SHOW_CONDITION, type: 'input' },
-    { name: CaseEventToFieldKeys.RetainHiddenValue, message: QUESTION_RETAIN_HIDDEN_VALUE, type: 'list', choices: YES_OR_NO },
     { name: CaseEventToFieldKeys.CallBackURLMidEvent, message: QUESTION_CALLBACK_URL_MID_EVENT, type: 'input' }
-  ], answers)
-}
-
-async function askForRegularExpression(answers: Answers = {}) {
-  return await prompt([
-    { name: CaseFieldKeys.RegularExpression, message: QUESTION_REGULAR_EXPRESSION, type: 'input' }
   ], answers)
 }
 

--- a/journeys/et/manageDuplicateField.ts
+++ b/journeys/et/manageDuplicateField.ts
@@ -1,10 +1,11 @@
 import { prompt } from 'inquirer'
 import { Journey } from 'types/journey'
-import { askCaseTypeID, fuzzySearch, listOrFreeType } from 'app/questions'
+import { fuzzySearch, listOrFreeType } from 'app/questions'
 import { getConfigSheetsForCaseTypeID, getKnownCaseTypeIDs } from 'app/et/configs'
 import { doDuplicateCaseField } from 'app/et/duplicateCaseField'
 import { CANCEL, NO_DUPLICATE } from 'app/constants'
 import { getIdealSizeForInquirer } from 'app/helpers'
+import { askCaseTypeID } from 'app/et/questions'
 
 const QUESTION_DUPLICATE = "What's the ID of the field to duplicate?"
 const QUESTION_DUPLICATE_ADDON = 'Do we need this field duplicated under another caseTypeID?'

--- a/journeys/et/validateCaseFieldAuths.ts
+++ b/journeys/et/validateCaseFieldAuths.ts
@@ -1,11 +1,11 @@
 import { AuthorisationCaseField, CaseField } from 'types/ccd'
 import { Journey } from 'types/journey'
-import { askCaseTypeID } from 'app/questions'
 import { getConfigSheetsForCaseTypeID, createCaseFieldAuthorisations } from 'app/et/configs'
 import { findMissing, matcher } from 'app/helpers'
 import { COMPOUND_KEYS } from 'app/constants'
 import { writeFileSync } from 'fs'
 import { resolve } from 'path'
+import { askCaseTypeID } from 'app/et/questions'
 
 /**
  * Checks over every CaseField for missing or unexpected authorisations.

--- a/types/ccd.ts
+++ b/types/ccd.ts
@@ -194,15 +194,17 @@ export enum ScrubbedKeys {
   DisplayOrder = 'DisplayOrder',
 }
 
-export const sheets: Array<keyof (ConfigSheets)> = [
-  'AuthorisationCaseEvent',
-  'AuthorisationCaseField',
-  'CaseEvent',
-  'CaseEventToFields',
-  'CaseField',
-  'EventToComplexTypes',
-  'Scrubbed'
-]
+const sheetsObj: CCDTypes = {
+  CaseEvent: null,
+  CaseEventToFields: null,
+  CaseField: null,
+  EventToComplexTypes: null,
+  AuthorisationCaseEvent: null,
+  AuthorisationCaseField: null,
+  Scrubbed: null
+}
+
+export const sheets = Object.keys(sheetsObj) as Array<keyof (CCDTypes)>
 
 export function createNewConfigSheets(): ConfigSheets {
   return sheets.reduce((acc, obj) => {


### PR DESCRIPTION
## TLDR

* giving more explicit error on failure to read JSON file
* refactored some common question logic out into generic question file
* createSingleField now doesn't need to be tied to an event
* stricter type checking on ConfigSheets
* template method for asking questions based on an object type

## Questions refactor

+ Further seperated ET specific logic from CCD questions.
+ Pulled out a lot of logic from the createSingleField journey into a new `et/questions.ts` file

## Template method for asking questions

Added a new method in `et/questions.ts` that will ask generic questions based on the keys of an objected provided to it. Gives the ability to take user input for creating a new object type without requiring explicit question logic. 

This shouldn't be relied upon as we miss out on the nicities of creating a journey, such as:

+ Validation
+ Hiding questions that arent relevent based on previous input
+ Bespoke question wording

Perhaps further work can be done in future to extend this?

## Other changes

+ More explicit error message on failure reading from JSON files (ie, what JSON file couldn't be read)
+ Stricter type checking on ConfigSheets
+ `createSingleField` now doesn't need to be tied to an event (ie, fields on ComplexTypes that don't get referenced in CaseEventToFields) 