### PR TITLE
Flex-28. Add journey to spin docker containers without pulling new images.

### DIFF
--- a/et/docker.ts
+++ b/et/docker.ts
@@ -8,10 +8,17 @@ export async function ensureUp() {
   await ccdLogin()
   await ccdComposePull()
   await ccdInit()
-  await ccdComposeUp()
-  await initEcm()
+  await startContainers()
   await initDb()
   clearCurrentLine()
+}
+
+/**
+ * Start and setup containers from existing images
+ */
+export async function startContainers() {
+  await ccdComposeUp()
+  await initEcm()
 }
 
 /**

--- a/journeys/et/dockerLoadAndSetup.ts
+++ b/journeys/et/dockerLoadAndSetup.ts
@@ -1,0 +1,8 @@
+import { ensureUp } from 'app/et/docker'
+import { Journey } from 'types/journey'
+
+export default {
+  group: 'et-docker',
+  text: 'Load new images & spin up docker containers for ET CCD',
+  fn: ensureUp
+} as Journey

--- a/journeys/et/dockerLoadAndSetup.ts
+++ b/journeys/et/dockerLoadAndSetup.ts
@@ -1,8 +1,0 @@
-import { ensureUp } from 'app/et/docker'
-import { Journey } from 'types/journey'
-
-export default {
-  group: 'et-docker',
-  text: 'Load new images & spin up docker containers for ET CCD',
-  fn: ensureUp
-} as Journey

--- a/journeys/et/dockerRun.ts
+++ b/journeys/et/dockerRun.ts
@@ -1,0 +1,8 @@
+import { startContainers } from 'app/et/docker'
+import { Journey } from 'types/journey'
+
+export default {
+  group: 'et-docker',
+  text: 'Spin up docker containers for ET CCD',
+  fn: startContainers
+} as Journey

--- a/journeys/et/dockerSetup.ts
+++ b/journeys/et/dockerSetup.ts
@@ -1,8 +1,8 @@
-import { ensureUp } from 'app/et/docker'
+import { startContainers } from 'app/et/docker'
 import { Journey } from 'types/journey'
 
 export default {
   group: 'et-docker',
   text: 'Spin up docker containers for ET CCD',
-  fn: ensureUp
+  fn: startContainers
 } as Journey

--- a/journeys/et/dockerSetup.ts
+++ b/journeys/et/dockerSetup.ts
@@ -1,8 +1,8 @@
-import { startContainers } from 'app/et/docker'
+import { ensureUp } from 'app/et/docker'
 import { Journey } from 'types/journey'
 
 export default {
   group: 'et-docker',
-  text: 'Spin up docker containers for ET CCD',
-  fn: startContainers
+  text: 'Load new images & spin up docker containers for ET CCD',
+  fn: ensureUp
 } as Journey


### PR DESCRIPTION
Fixes #28.
Changed the wording on an existing journey.