### PR TITLE
fix for #55 - hung dm-store

### DIFF
--- a/et/docker.ts
+++ b/et/docker.ts
@@ -264,3 +264,14 @@ export async function recreateWslUptimeContainer() {
   await execCommand('docker rm wsl_uptime', null, false)
   await execCommand('docker run -e "WSL_HOSTNAME=$(hostname -I)" -d --name "wsl_uptime" jackreeve532/wsluptimechecker:latest', null, false)
 }
+
+export async function isDmStoreReady() {
+  const { stdout } = await execCommand('docker logs compose-dm-store-1')
+  const logs = stdout.split('\n')
+  const currentSessionLogs = logs.slice(logs.findIndex(o => o.startsWith(' :: Spring Boot ::')))
+  return currentSessionLogs.some(o => o.match(/Started DmApp in [\d.]+ seconds/))
+}
+
+export async function rebootDmStore() {
+  return await execCommand('docker restart compose-dm-store-1')
+}

--- a/helpers.ts
+++ b/helpers.ts
@@ -207,3 +207,5 @@ export function clearCurrentLine() {
 export function getIdealSizeForInquirer() {
   return process.stdout.rows - 2
 }
+
+export function wait(ms: number) { return new Promise(resolve => setTimeout(resolve, ms)) }

--- a/journeys/et/dockerCommon.ts
+++ b/journeys/et/dockerCommon.ts
@@ -1,8 +1,8 @@
 import { Journey } from 'types/journey'
 import { prompt } from 'inquirer'
-import { ccdComposePull, ccdComposeUp, ccdInit, ccdLogin, dockerDeleteVolumes, dockerSystemPrune, initDb, initEcm, killAndRemoveContainers, recreateWslUptimeContainer } from 'app/et/docker'
+import { ccdComposePull, ccdComposeUp, ccdInit, ccdLogin, dockerDeleteVolumes, dockerSystemPrune, initDb, initEcm, isDmStoreReady, killAndRemoveContainers, rebootDmStore, recreateWslUptimeContainer } from 'app/et/docker'
 import { askConfigTasks, execConfigTasks } from './configsCommon'
-import { getIdealSizeForInquirer } from 'app/helpers'
+import { getIdealSizeForInquirer, temporaryLog, wait } from 'app/helpers'
 import { askCreateCaseQuestions, doCreateCaseTasks } from './webCreateCase'
 
 const QUESTION_TASK = 'What stages of setup are you interested in?'
@@ -60,6 +60,7 @@ export async function configsJourney() {
   if (answers.tasks.includes(TASK_CHOICES.UP)) {
     await ccdComposeUp()
     await recreateWslUptimeContainer()
+    await waitForDmStore()
   }
 
   if (answers.tasks.includes(TASK_CHOICES.INIT_ECM)) {
@@ -78,6 +79,27 @@ export async function configsJourney() {
     await doCreateCaseTasks(createAnswers)
   }
 }
+
+async function waitForDmStore() {
+  let timeout = 45
+  let left = timeout
+
+  while (!(await isDmStoreReady())) {
+    temporaryLog(`Waiting for dm-store to be ready (or will restart in ${Math.round(left)} seconds)`)
+
+    if (left <= 0) {
+      // Makeshift backoff (45, 68, 102, 152 etc...)
+      timeout *= 1.5
+      left = timeout
+      temporaryLog(`Restarting dm-store container`)
+      await rebootDmStore()
+    }
+
+    await wait(10000)
+    left -= 10
+  }
+}
+
 
 export default {
   group: 'et-docker',

--- a/journeys/et/webCreateCase.ts
+++ b/journeys/et/webCreateCase.ts
@@ -56,7 +56,6 @@ export async function doCreateCaseTasks(answers: Record<string, any>) {
   const needToRevert = getWslHostIP() === 'host.docker.internal'
 
   if (answers.callbacks === YES) {
-    await fixExitedContainers()
     await killProcessesOnPort8081()
     await setIPToWslHostAddress()
     await generateSpreadsheets('local')
@@ -65,6 +64,8 @@ export async function doCreateCaseTasks(answers: Record<string, any>) {
     temporaryLog('Callbacks has started up')
   }
 
+  await fixExitedContainers()
+  
   for (const region of answers.region) {
     await createNewCase(region, answers.events)
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-hmcts-helpers",
-  "version": "1.1.23012301",
+  "version": "1.1.23020601",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Waiting for dm-store to start up. Reads the logs from the docker container and waits for a "Started DmApp" message, If message is not received within X seconds, restart the container and try again. Uses an exponential backoff, to account for slower machines. Usually it only needs one reboot due to out of order dependencies set out by the ecm scripts.