### PR TITLE
fix for #58 - retainhiddenvalue

### DIFF
--- a/journeys/et/createSingleField.ts
+++ b/journeys/et/createSingleField.ts
@@ -85,7 +85,7 @@ export async function createSingleField(answers: Answers = {}) {
   }
 
   if (askEvent && answers[CaseEventToFieldKeys.FieldShowCondition]) {
-    answers = await askRetainHiddenValue(answers, existingCaseEventToField?.RetainHiddenValue)
+    answers = await askRetainHiddenValue(answers, undefined, undefined, existingCaseEventToField?.RetainHiddenValue)
   }
 
   if (existingField) {


### PR DESCRIPTION
RetainHiddenValue was being stored on Answers object as "Yes", resulting in it not going into the created ccd object. `askRetainHiddenValue` method had updated but `createSingleField` had not been updated to support this