### PR TITLE
excluding ethos logstash from the defaults check

### DIFF
--- a/journeys/et/dockerCommon.ts
+++ b/journeys/et/dockerCommon.ts
@@ -28,7 +28,7 @@ async function getDefaultTasks(tasks: TASK_CHOICES) {
     tasks.UP
   ]
 
-  if (!await doAllContainersExist()) {
+  if (!await doAllContainersExist(['ethos-logstash'])) {
     return Object.values(tasks).slice(1)
   }
 

--- a/journeys/et/webCreateCase.ts
+++ b/journeys/et/webCreateCase.ts
@@ -61,7 +61,12 @@ export async function doCreateCaseTasks(answers: Record<string, any>) {
     await setIPToWslHostAddress()
     await generateSpreadsheets('local')
     await importConfigs()
-    await startAndWaitForCallbacksToBeReady()
+    try {
+      await startAndWaitForCallbacksToBeReady()
+    } catch (e) {
+      console.log(`Failed to start callbacks - aborting journey :(`)
+      return
+    }
     temporaryLog('Callbacks has started up')
   }
 


### PR DESCRIPTION
* isDmStoreReady() will not crash if docker has an error
* doAllContainers exist now takes an exclude array so we can exclude ethos-logstash from the Docker / ECM setup defaults (#69 )
* flex no longer crashes if callbacks cannot start on the createCase journey (it will just abort and return to the main menu)