### PR TITLE
fix for #71 and clarity on pulling images

### DIFF
--- a/journeys/et/dockerCommon.ts
+++ b/journeys/et/dockerCommon.ts
@@ -53,7 +53,7 @@ export async function configsJourney() {
     RESTART_WSL_UPTIME: `Restart the wsl-uptime container (${wslAddon})`,
     DOWN_CONTAINERS: `Kill and remove docker containers associated with ExUI`,
     REMOVE_VOLUMES: 'Delete volumes associated with old containers (useful for clearing elastic search errors)',
-    PRUNE: 'Docker prune to get rid of everything not currently in use (docker system prune --volumes -f)',
+    PRUNE: 'Docker prune to get rid of everything not currently in use (docker system prune --volumes -f && docker image prune -f -a)',
     PULL: 'Pull the latest images (./ccd compose pull)',
     INIT_CCD: 'Create ccd network in docker (only needed if docker was destroyed) (./ccd init)',
     UP: 'Run up/build containers from existing images (./ccd compose up -d)',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-hmcts-helpers",
-  "version": "1.1.23021501",
+  "version": "1.1.23022301",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Added new command to the prune function `docker image prune -f -a`. The -a is the part required to delete (a)ll images rather than just "dangling" ones.

Improved the display readout for pulling docker images. Especially useful for those on slower networks