### PR TITLE
fix for non consecutive display orders inserting at the bottom on events

### DIFF
--- a/et/configs.ts
+++ b/et/configs.ts
@@ -424,7 +424,7 @@ function spliceIndexScrubbed(x: Scrubbed, arr: Scrubbed[]) {
 }
 
 function spliceIndexCaseEvent(x: CaseEvent, arr: CaseEvent[]) {
-  let index = findLastIndex(arr, o => o.ID === x.ID && o.CaseTypeID === x.CaseTypeID) + 1
+  let index = findLastIndex(arr, o => o.CaseTypeID === x.CaseTypeID) + 1
 
   if (x.DisplayOrder === 1) {
     index = arr.findIndex(o => o.CaseTypeID === x.CaseTypeID)


### PR DESCRIPTION
Group events with their caseTypeId even if the display order doesnt follow on from previous