### PR TITLE
CaseEvent question improvements (DisplayOrder and shortcut for EventEnablingCondition)

### DIFF
--- a/ccd.ts
+++ b/ccd.ts
@@ -19,7 +19,7 @@ export function createNewCaseEvent(answers?: AllCCDKeys): CaseEvent {
     ID: answers?.ID || '',
     Name: answers?.Name || '',
     Description: answers?.Description || '',
-    DisplayOrder: answers?.DisplayOrder || 1,
+    DisplayOrder: answers?.DisplayOrder,
     'PreConditionState(s)': answers?.['PreConditionState(s)'] || '*',
     PostConditionState: answers?.PostConditionState || '*',
     SecurityClassification: 'Public',

--- a/journeys/base/createEvent.ts
+++ b/journeys/base/createEvent.ts
@@ -2,7 +2,7 @@ import { prompt } from 'inquirer'
 import { Journey } from 'types/journey'
 import { addCaseEvent, addCaseTypeIDQuestion, addDuplicateToCaseTypeID, Answers, Question, spliceCustomQuestionIndex } from 'app/questions'
 import { createNewCaseEvent } from 'app/ccd'
-import { Y_OR_N } from 'app/constants'
+import { Y_OR_N, YES, YES_OR_NO } from 'app/constants'
 import { CaseEvent, CaseEventKeys } from 'app/types/ccd'
 import { duplicateForCaseTypeIDs, findObject, upsertConfigs } from 'app/configs'
 import { addToSession } from 'app/session'
@@ -11,10 +11,11 @@ import { format, upsertFields } from 'app/helpers'
 export const QUESTION_ID = 'What\'s the ID of the Event?'
 export const QUESTION_NAME = 'Give the {0} event a name (shows in the next steps dropdown)'
 export const QUESTION_DESCRIPTION = 'Give the new event a description'
-export const QUESTION_DISPLAY_ORDER = 'Where should this event appear in the caseEvent dropdown (DisplayOrder)?'
+export const QUESTION_DISPLAY_ORDER = 'Where should this event appear in the caseEvent dropdown (use -1 to leave empty) (DisplayOrder)?'
 export const QUESTION_PRECONDITION_STATES = 'What state should the case be in to see this page? (PreConditionState(s))'
 export const QUESTION_POST_CONDITION_STATE = 'What state should the case be set to after completing this journey? (PostConditionState)'
 export const QUESTION_EVENT_ENABLING_CONDITION = 'Enter a condition for showing this event in the "Next step" dropdown? (EventEnablingCondition) (optional)'
+export const QUESTION_EVENT_ENABLING_CONDITION_SHORTCUT = 'Would you like to use \'caseType="dummy"\' for the EventEnablingCondition to hide it from the "Next step" dropdown?'
 export const QUESTION_SHOW_EVENT_NOTES = 'Provide a value for ShowEventNotes'
 export const QUESTION_SHOW_SUMMARY = 'Should there be a Check Your Answers page at the end of this event?'
 export const QUESTION_CALLBACK_URL_ABOUT_TO_START_EVENT = 'Do we need a callback before we start? (optional)'
@@ -44,10 +45,11 @@ export function addEventQuestions(existingFn: (answers: Answers) => CaseEvent = 
     ...addCaseEvent({ name: CaseEventKeys.ID, message: QUESTION_ID }, false),
     { name: 'Name', message: (answers: Answers) => format(QUESTION_NAME, answers.ID), default: defaultFn('Name', (answers: Answers) => answers.ID) },
     { name: 'Description', message: QUESTION_DESCRIPTION, default: defaultFn('Description') },
-    { name: 'DisplayOrder', message: QUESTION_DISPLAY_ORDER, type: 'number', default: defaultFn('DisplayOrder', 1) },
+    { name: 'DisplayOrder', message: QUESTION_DISPLAY_ORDER, type: 'number', default: defaultFn('DisplayOrder', 1), filter: (input: number) => input < 0 ? undefined : input },
+    { name: 'EventEnablingCondition', message: QUESTION_EVENT_ENABLING_CONDITION_SHORTCUT, type: 'list', choices: YES_OR_NO, filter: input => input === YES ? 'caseType="dummy"' : undefined, when: (ans: Answers) => !ans.DisplayOrder },
+    { name: 'EventEnablingCondition', message: QUESTION_EVENT_ENABLING_CONDITION, default: defaultFn('EventEnablingCondition') },
     { name: 'PreConditionState(s)', message: QUESTION_PRECONDITION_STATES, default: defaultFn('PreConditionState(s)', '*') },
     { name: 'PostConditionState', message: QUESTION_POST_CONDITION_STATE, default: defaultFn('PostConditionState', '*') },
-    { name: 'EventEnablingCondition', message: QUESTION_EVENT_ENABLING_CONDITION, default: defaultFn('EventEnablingCondition') },
     { name: 'ShowEventNotes', message: QUESTION_SHOW_EVENT_NOTES, type: 'list', choices: Y_OR_N, default: defaultFn('ShowEventNotes', 'N') },
     { name: 'ShowSummary', message: QUESTION_SHOW_SUMMARY, type: 'list', choices: Y_OR_N, default: defaultFn('ShowSummary', 'Y') },
     { name: 'CallBackURLAboutToStartEvent', message: QUESTION_CALLBACK_URL_ABOUT_TO_START_EVENT, default: defaultFn('CallBackURLAboutToStartEvent') },


### PR DESCRIPTION
* CaseEvent.DisplayOrder is now conditional (use a negative number to not output it)
* CaseEvent base journey will now ask an optional shortcut question for EventEnablingCondition if the DisplayOrder is negative

