### PR TITLE
Create Case and Uploading configs now support different environments

### DIFF
--- a/journeys/et/configsCommon.ts
+++ b/journeys/et/configsCommon.ts
@@ -3,7 +3,7 @@ import { Journey } from 'types/journey'
 import { prompt } from 'inquirer'
 import { Region, saveBackToProject } from 'app/et/configs'
 import { setIPToHostDockerInternal, setIPToWslHostAddress } from './dockerUpdateIP'
-import { execCommand, getFiles, getIdealSizeForInquirer, isRunningInWsl, temporaryLog, wait } from 'app/helpers'
+import { execCommand, format, getFiles, getIdealSizeForInquirer, isRunningInWsl, temporaryLog, wait } from 'app/helpers'
 import { createReadStream, statSync } from 'fs'
 import FormData from 'form-data'
 import fetch from 'node-fetch'
@@ -15,7 +15,7 @@ import { fixExitedContainers } from 'app/et/docker'
 const QUESTION_TASK = 'What stages of import are you interested in?'
 const QUESTION_ENVIRONMENT = 'What environment should we generate spreadsheets for?'
 const QUESTION_IP = 'What IP should be used for ExUI to talk to callbacks?'
-const QUESTION_UPLOAD = 'Would you like to upload demo configs to the demo environment?'
+const QUESTION_UPLOAD = 'Would you like to upload configs to the {0} environment?'
 
 const CHOICE_SAVE = 'Save in-memory config'
 const CHOICE_GENERATE = 'Generate spreadsheets from JSON files'
@@ -28,6 +28,13 @@ const IP_OPTS = [
   'host.docker.internal (if callbacks runs on Windows/Mac)',
   'WSL IP (if callbacks runs inside WSL)'
 ]
+
+export const ENV_CONFIG = {
+  USER: '',
+  PASS: '',
+  BASE_URL: '',
+  IDAM_LOGIN_START_URL: ''
+}
 
 export function getConfigChoices() {
   return {
@@ -60,8 +67,8 @@ export async function askConfigTasks() {
     return answers
   }
 
-  if (answers.env === 'demo') {
-    answers = await prompt([{ name: 'upload', message: QUESTION_UPLOAD, type: 'list', choices: YES_OR_NO, default: YES }], answers)
+  if (answers.env !== 'local') {
+    answers = await prompt([{ name: 'upload', message: format(QUESTION_UPLOAD, answers.env), type: 'list', choices: YES_OR_NO, default: YES }], answers)
   }
 
   return answers
@@ -100,10 +107,11 @@ export async function execConfigTasks(answers: Record<string, any>) {
   }
 
   if (answers.upload === YES) {
-    const cookieJar = await loginToIdam(process.env.DEMO_ADMIN_USER, process.env.DEMO_ADMIN_PASS, 'https://ccd-admin-web.demo.platform.hmcts.net')
+    setCredentialsForEnvironment(answers.env)
+    const cookieJar = await loginToIdam(ENV_CONFIG.USER, ENV_CONFIG.PASS, ENV_CONFIG.BASE_URL)
     const cookie = cookieJarToString(cookieJar)
-    await uploadConfig(process.env.ENGWALES_DEF_DIR, cookie)
-    await uploadConfig(process.env.SCOTLAND_DEF_DIR, cookie)
+    await uploadConfig(process.env.ENGWALES_DEF_DIR, answers.env, cookie)
+    await uploadConfig(process.env.SCOTLAND_DEF_DIR, answers.env, cookie)
   }
 }
 
@@ -143,12 +151,12 @@ export async function importConfigs() {
   await ccdImport(Region.Scotland)
 }
 
-async function uploadConfig(dir: string, cookie: string) {
+async function uploadConfig(dir: string, env: string, cookie: string) {
   const files = await getFiles(`${dir}/definitions/xlsx`)
-  const configFile = files.find(o => o.match(/et-(englandwales|scotland)-ccd-config-demo\.xlsx/))
+  const configFile = files.find(o => o.match(new RegExp(`et-(englandwales|scotland)-ccd-config-${env}\\.xlsx`)))
 
   if (!configFile) {
-    return temporaryLog(`Could not find a demo config file in ${dir}/definitions/xlsx`)
+    return temporaryLog(`Could not find a ${env} config file in ${dir}/definitions/xlsx`)
   }
 
   const form = new FormData()
@@ -157,11 +165,11 @@ async function uploadConfig(dir: string, cookie: string) {
   const fileStream = createReadStream(configFile)
   form.append('file', fileStream, { knownLength: fileSizeInBytes })
 
-  await fetch('https://ccd-admin-web.demo.platform.hmcts.net/import', {
+  await fetch(`${ENV_CONFIG.BASE_URL}/import`, {
     method: 'POST',
     headers: {
       Cookie: cookie,
-      referrer: ' https://ccd-admin-web.demo.platform.hmcts.net/',
+      referrer: ENV_CONFIG.BASE_URL,
       'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36'
     },
     body: form
@@ -171,11 +179,11 @@ async function uploadConfig(dir: string, cookie: string) {
 }
 
 async function verifyUpload(cookie: string) {
-  const res = await fetch('https://ccd-admin-web.demo.platform.hmcts.net/import', {
+  const res = await fetch(`${ENV_CONFIG.BASE_URL}/import`, {
     method: 'GET',
     headers: {
       Cookie: cookie,
-      referrer: ' https://ccd-admin-web.demo.platform.hmcts.net/',
+      referrer: ENV_CONFIG.BASE_URL,
       'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36'
     }
   })
@@ -193,6 +201,21 @@ async function verifyUpload(cookie: string) {
   }
 
   return true
+}
+
+function setCredentialsForEnvironment(env: string) {
+  const importUser = process.env[`${env.toUpperCase()}_IMPORT_USER`]
+  const importPass = process.env[`${env.toUpperCase()}_IMPORT_PASS`]
+  const importUrl = process.env[`${env.toUpperCase()}_IMPORT_URL`]
+
+  if (!importUser || !importPass || !importUrl) {
+    throw new Error(`Could not find credentials for environment - Please make sure ${env.toUpperCase()}_IMPORT_USER, ${env.toUpperCase()}_IMPORT_PASS and ${env.toUpperCase()}_IMPORT_URL are set as environment variables`)
+  }
+
+  ENV_CONFIG.USER = importUser
+  ENV_CONFIG.PASS = importPass
+  ENV_CONFIG.BASE_URL = importUrl
+  ENV_CONFIG.IDAM_LOGIN_START_URL = `${importUrl}/auth/login`
 }
 
 export default {

--- a/journeys/et/webCreateCase.ts
+++ b/journeys/et/webCreateCase.ts
@@ -8,7 +8,7 @@ import { createReadStream, existsSync, statSync } from 'fs'
 import { NO, YES, YES_OR_NO } from 'app/constants'
 import { execCommand, getEnvVarsFromFile, getIdealSizeForInquirer, temporaryLog, wait } from 'app/helpers'
 import { ChildProcess, exec } from 'child_process'
-import { getWslHostIP, setIPToHostDockerInternal, setIPToWslHostAddress } from './dockerUpdateIP'
+import { getWslHostIP, setIPToHostDockerInternal } from './dockerUpdateIP'
 import { generateSpreadsheets, importConfigs } from './configsCommon'
 import { fixExitedContainers } from 'app/et/docker'
 import FormData from 'form-data'
@@ -143,7 +143,6 @@ export async function doCreateCaseTasks(answers: Record<string, any>) {
 
   if (answers.callbacks === YES) {
     await killProcessesOnPort8081()
-    await setIPToWslHostAddress()
     await generateSpreadsheets('local')
     await importConfigs()
     try {
@@ -238,14 +237,12 @@ export async function startAndWaitForCallbacksToBeReady(): Promise<ChildProcess>
   })
 }
 
-export async function getInitialLoginUrl(url: string = ENV_CONFIG.IDAM_LOGIN_START_URL) {
+export async function getInitialLoginUrl(url: string = ENV_CONFIG.IDAM_LOGIN_START_URL, cookieJar: CookieJar = { seen_cookie_message: 'yes', cookies_policy: '{ "essential": true, "analytics": false, "apm": false }', cookies_preferences_set: 'false' }) {
   const res = await fetch(url, { redirect: 'manual' })
 
   if (res.status !== 302) {
     throw new Error(`Something went wrong calling IDAM LOGIN - expected 302 but got ${res.status}`)
   }
-
-  const cookieJar = { seen_cookie_message: 'yes', cookies_policy: '{ "essential": true, "analytics": false, "apm": false }', cookies_preferences_set: 'false' }
 
   return {
     location: res.headers.get('location') || '',
@@ -261,10 +258,15 @@ export async function getCsrfTokenFromLoginPage(authUrl: string, cookieJar: Cook
 }
 
 export async function loginToIdam(username = ENV_CONFIG.USER, password = ENV_CONFIG.PASS, unauthorisedUrl = ENV_CONFIG.IDAM_LOGIN_START_URL) {
-  const { location: authUrl, cookieJar } = await getInitialLoginUrl(unauthorisedUrl)
+  let { location: authUrl, cookieJar } = await getInitialLoginUrl(unauthorisedUrl)
+  if (authUrl.includes('/o/authorize?')) {
+    const authorize = await getInitialLoginUrl(authUrl, cookieJar)
+    authUrl = authorize.location
+    cookieJar = authorize.cookieJar
+  }
   const csrf = await getCsrfTokenFromLoginPage(authUrl, cookieJar)
 
-  const body = objToFormData({ username, password, save: 'Sign in', selfRegistrationEnabled: 'true', azureLoginEnabled: 'true', mojLoginEnabled: 'true', _csrf: csrf })
+  const body = objToFormData({ username, password, selfRegistrationEnabled: 'false', azureLoginEnabled: 'true', mojLoginEnabled: 'true', _csrf: csrf })
 
   const res = await fetch(authUrl, {
     method: 'POST',

--- a/journeys/et/webCreateCase.ts
+++ b/journeys/et/webCreateCase.ts
@@ -83,8 +83,8 @@ function setCredentialsForEnvironment(env: string) {
 
   ENV_CONFIG.USER = user
   ENV_CONFIG.PASS = pass
-  ENV_CONFIG.BASE_URL = url
-  ENV_CONFIG.IDAM_LOGIN_START_URL = `${url}/auth/login`
+  ENV_CONFIG.BASE_URL = url.endsWith('/') ? url.slice(0, -1) : url
+  ENV_CONFIG.IDAM_LOGIN_START_URL = `${ENV_CONFIG.BASE_URL}/auth/login`
 }
 
 async function askCreateOrExistingCase() {


### PR DESCRIPTION
Create Case and Upload configs now supports Preview, Demo, ITHC environments as well as local

Will throw out errors if the following envvars are not found when trying to upload to that environment (redacted passwords, get them from confluence):

LOCAL_IDAM_USER="et.dev@hmcts.net"
LOCAL_IDAM_PASS=""
LOCAL_EXUI_URL="http://localhost:3455"

PREVIEW_IDAM_USER="et.api.1@hmcts.net"
PREVIEW_IDAM_PASS=""
PREVIEW_EXUI_URL="https://xui-et-ccd-definitions-admin-pr-95.preview.platform.hmcts.net"
PREVIEW_IMPORT_USER="servicesatcdm+ethos@gmail.com"
PREVIEW_IMPORT_PASS=""
PREVIEW_IMPORT_URL="https://admin-web-et-ccd-definitions-admin-pr-95.preview.platform.hmcts.net"

DEMO_IDAM_USER="et.api.1@hmcts.net"
DEMO_IDAM_PASS="
DEMO_EXUI_URL="https://manage-case.demo.platform.hmcts.net"
DEMO_IMPORT_USER="servicesatcdmethos@mailinator.com"
DEMO_IMPORT_PASS=""
DEMO_IMPORT_URL="https://ccd-admin-web.demo.platform.hmcts.net"

ITHC_IDAM_USER="api.caseworker@hmcts.net"
ITHC_IDAM_PASS=""
ITHC_EXUI_URL="https://manage-case.ithc.platform.hmcts.net"
ITHC_IMPORT_USER="ccdimport.employment@hmcts.net"
ITHC_IMPORT_PASS=""
ITHC_IMPORT_URL="https://ccd-admin-web.ithc.platform.hmcts.net"